### PR TITLE
Make redirect matching case-insensitive by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,16 +109,15 @@ will (or have) setup in Cloudflare and use the following format:
   "name":"example.com",
   "redirects": [
     {
-      "base": "*example.com",
       "from": "/(.*)",
       "to": "https://example.org/$1",
-      "status": 301
     },
     {
       "base": "www.example.com",
       "from": "/only-on-www",
       "to": "https://example.org/www-was-here",
-      "status": 301
+      "status": 301,
+      "caseSensitive": true
     }
   ]
 }
@@ -126,6 +125,10 @@ will (or have) setup in Cloudflare and use the following format:
 
 The `redirects.base` key, if absent is presumed to be `*${name}/*` when
 creating Page Rule based redirects.
+
+The `redirects.status` key, if not specified has a default value of `301`.
+
+The `redirects.caseSensitive` key, if not specified has default value of `false`.
 
 ## License
 


### PR DESCRIPTION
Add option to specify whether a redirect requires case-sensitive matching or not.

NOTE: Currently CloudFlare page rules are case-insensitive, but the web-redirects-cli worker implementation is **case-sensitive**.
This change will make worker redirects behave the same as page rules by default - but adds the ability to enforce case-sensitivity if require.
