### PR TITLE
Fix: make getZonesByName() function per account

### DIFF
--- a/commands/worker.js
+++ b/commands/worker.js
@@ -33,7 +33,7 @@ const handler = (argv) => {
     })
     .catch(console.error);
   // get the zone ID for the domain in question
-  getZonesByName(domain)
+  getZonesByName(domain, argv.accountId)
     .then((results) => {
       switch (results.length) {
         case 0:

--- a/lib/cloudflare.js
+++ b/lib/cloudflare.js
@@ -86,7 +86,7 @@ const cloudflareUpdate = async (method, path, data) => {
 const getAccountById = async (accountId) => cloudflareGet(`/accounts/${accountId}`, true);
 const getZonesByAccount = async (accountId) => cloudflareGet(`/zones?account.id=${accountId}`, false);
 const getZoneById = async (zoneId) => cloudflareGet(`/zones/${zoneId}`, true);
-const getZonesByName = async (zoneName) => cloudflareGet(`/zones?name=${zoneName}`, false);
+const getZonesByName = async (zoneName, accountId) => cloudflareGet(`/zones?name=${zoneName}&account.id=${accountId}`, false);
 const getDnsRecordsByZoneId = async (zoneId) => cloudflareGet(`/zones/${zoneId}/dns_records`, false);
 const getPageRulesByZoneId = async (zoneId) => cloudflareGet(`/zones/${zoneId}/pagerules`, false);
 const getZoneSettingsById = async (zoneId) => cloudflareGet(`/zones/${zoneId}/settings`, false);


### PR DESCRIPTION
Defining workers for a zone that was already in Cloudflare (being migrated) failed because 2 zones were found when searching for zone id. 

As worker updates will only ever be applied to zones within the configured account - the API call now includes the account id parameter.